### PR TITLE
Missing SSL library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PHPMYADNIN_PACKAGE phpMyAdmin-$PHPMYADMIN_VERSION-english
 ENV PHPMYADMIN_DOWNLOAD https://files.phpmyadmin.net/phpMyAdmin/$PHPMYADMIN_VERSION/$PHPMYADNIN_PACKAGE.tar.gz
 
 RUN \
-  apk add -U apache2 php-apache2 php-mysqli php-zip php-zlib php-bz2 php-ctype php-gd php-mcrypt php-json && \
+  apk add -U apache2 php-apache2 php-mysqli php-zip php-zlib php-bz2 php-ctype php-gd php-mcrypt php-json php-openssl && \
   rm -fr /var/cache/apk/* && \
   rm -fr /usr/bin/php
 


### PR DESCRIPTION
If you want to use something like:

```
 $cfg['Servers'][$i]['ssl_ca'] = '/usr/share/webapps/phpmyadmin/ssl/rds-combined.pem';
```

You need to install also support for SSL (openssl)
