### PR TITLE
Allow adjusting PHP memory limits using env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@
       -P \
       splattael/phpmyadmin
 
+### Environment variables
+
+* `-e PHP_UPLOAD_MAX_FILESIZE=2M`
+* `-e PHP_POST_MAX_SIZE=8M`
+* `-e PHP_MEMORY_LIMIT=128M`
+
 ### mod_remoteip.so
 
 By default the HTTP header `X-Forwarded-For` is used in access log

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+export PHP_UPLOAD_MAX_FILESIZE=${PHP_UPLOAD_MAX_FILESIZE:-2M}
+export PHP_POST_MAX_SIZE=${PHP_POST_MAX_SIZE:-8M}
+export PHP_MEMORY_LIMIT=${PHP_MEMORY_LIMIT:-128M}
+
 config=$PHPMYADMIN_DIR/config.inc.php
 if [ "`grep NO_SECRET $config`" != "" ]; then
   secret=$(cat /dev/urandom  | uuencode -m - | head -2 | tail -1)

--- a/phpmyadmin.conf
+++ b/phpmyadmin.conf
@@ -9,4 +9,7 @@ Alias /phpmyadmin "/usr/share/webapps/phpmyadmin"
   Options FollowSymlinks
   Order allow,deny
   Allow from all
+  php_value upload_max_filesize ${PHP_UPLOAD_MAX_FILESIZE}
+  php_value post_max_size ${PHP_POST_MAX_SIZE}
+  php_value memory_limit ${PHP_MEMORY_LIMIT}
 </Directory>


### PR DESCRIPTION
I have a (test) case to import a quite large SQL file using this container. To get this working I had to adjust the PHP memory limits.

Using environment variables (with defaults) seems to work good in this case.
